### PR TITLE
fix prerender config and make requests client side

### DIFF
--- a/src/components/transaction-box/TransactionBox.svelte
+++ b/src/components/transaction-box/TransactionBox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Box from '@components/_base/box/Box.svelte'
   import { shortenAddress } from '@utils'
-  import type { Transaction } from 'src/routes/explorer/transaction/[transaction]/+page.server'
+  import type { Transaction } from 'src/routes/explorer/transaction/[transaction]/+page'
 
   export let tx: Transaction
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,3 @@
-<script context="module">
-  export const prerender = true
-</script>
-
 <script lang="ts">
   import Header from '@components/header/Header.svelte'
   import { darkTheme, getCssText } from '@styles'

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+export const prerender = true

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,3 +1,0 @@
-<script context="module">
-  export const prerender = true
-</script>

--- a/src/routes/deploy-package/+page.svelte
+++ b/src/routes/deploy-package/+page.svelte
@@ -1,7 +1,6 @@
 <script>
   import DeployPackage from '@components/deploy-package/DeployPackage.svelte'
   import Box from '@components/_base/box/Box.svelte'
-  export const prerender = true
 </script>
 
 <Box mx="large" transparent>

--- a/src/routes/explorer/+layout.svelte
+++ b/src/routes/explorer/+layout.svelte
@@ -1,7 +1,3 @@
-<script context="module">
-  export const prerender = true
-</script>
-
 <script lang="ts">
   import { goto } from '$app/navigation'
   import Search from '@components/_base/search/Search.svelte'

--- a/src/routes/explorer/+page.svelte
+++ b/src/routes/explorer/+page.svelte
@@ -1,3 +1,0 @@
-<script context="module">
-  export const prerender = true
-</script>

--- a/src/routes/explorer/transaction/[transaction]/+page.ts
+++ b/src/routes/explorer/transaction/[transaction]/+page.ts
@@ -1,6 +1,8 @@
 import type { PageServerLoad } from './$types'
 import { queryServer } from '@queries'
 
+export const prerender = false
+
 type Action = {
   from: string
   to: string

--- a/src/routes/staking/+page.svelte
+++ b/src/routes/staking/+page.svelte
@@ -1,7 +1,3 @@
-<script context="module">
-  export const prerender = true
-</script>
-
 <script lang="ts">
   import ValidatorList from '@components/validator-list/ValidatorList.svelte'
   import type { PageData } from './$types'

--- a/src/routes/staking/+page.ts
+++ b/src/routes/staking/+page.ts
@@ -1,8 +1,6 @@
 import { queryServer } from '@queries'
 import type { PageServerLoad } from './$types'
 
-export const prerender = true
-
 export const load: PageServerLoad = async () => ({
   validators: await queryServer('getValidators')
 })


### PR DESCRIPTION
Updates the rendering config to be aligned with the current version of SvelteKit.

Now, our app actually prerenders, and hydrates with dynamic content.

The fetch queries were also moved to client side (renaming `+page.server.ts` to `+page.ts`), since I think devops preferred it that way to decrease server load. We can easily change this back if we want later.