### PR TITLE
fix: badge select selector doesnt refreshes

### DIFF
--- a/src/components/deploy-package/DeployPackageForm.svelte
+++ b/src/components/deploy-package/DeployPackageForm.svelte
@@ -48,6 +48,16 @@
 
   export let isDeploying = false
   export let onDeploy: (payload: DeployPayload) => void
+
+  const selectBadgeOptions = () =>
+    $state.context.non_fungible_resources.map((resource, i) => ({
+      id: i,
+      label: `${resource.name ?? ''} ${
+        resource.name ? '(' : ' '
+      }${getNFTAddress(resource.address, resource.id)}${
+        resource.name ? ')' : ' '
+      }`
+    }))
 </script>
 
 <Box>
@@ -90,13 +100,11 @@
             type: 'SELECT_ACCOUNT',
             address: e.account.address
           })}
-        options={[
-          ...($accounts || []).map((account, i) => ({
-            account,
-            id: i,
-            label: `${account.label} (${shortenAddress(account.address)})`
-          }))
-        ]}
+        options={($accounts || []).map((account, i) => ({
+          account,
+          id: i,
+          label: `${account.label} (${shortenAddress(account.address)})`
+        }))}
       />
     </Box>
     <Box>
@@ -108,16 +116,7 @@
               type: 'SELECT_BADGE',
               index: e.id
             })}
-          options={[
-            ...$state.context.non_fungible_resources.map((resource, i) => ({
-              id: i,
-              label: `${resource.name ?? ''} ${
-                resource.name ? '(' : ' '
-              }${getNFTAddress(resource.address, resource.id)}${
-                resource.name ? ')' : ' '
-              }`
-            }))
-          ]}
+          options={selectBadgeOptions()}
         />
       {:else}
         <Select placeholder="Select Badge NFT" />

--- a/src/components/deploy-package/deploy-package-form-state-machine.test.ts
+++ b/src/components/deploy-package/deploy-package-form-state-machine.test.ts
@@ -1,0 +1,93 @@
+import { interpret } from 'xstate'
+import { stateMachine } from './deploy-package-state-machine'
+
+describe('#deploy state machine', () => {
+  it('should transition from not-connected to connected', () => {
+    expect(
+      stateMachine
+        .transition('connect.idle', 'CONNECT')
+        .matches('connect.success')
+    ).toBeTruthy()
+  })
+
+  it('should succeed transition from deploy.idle to deploy.pending', () => {
+    expect(
+      stateMachine
+        .transition('deploy.idle', {
+          type: 'DEPLOY',
+          payload: {
+            badge: {
+              name: 'test',
+              address: 'test',
+              id: 'test'
+            },
+            account: 'account',
+            wasm: 'wasm',
+            abi: 'abi'
+          }
+        })
+        .matches('deploy.pending')
+    ).toBeTruthy()
+  })
+
+  it('should fail transition from deploy.idle to deploy.pending due to failed conditions', () => {
+    expect(
+      stateMachine
+        .transition('deploy.idle', {
+          type: 'DEPLOY',
+          // @ts-ignore - this is a test
+          payload: {
+            badge: {
+              name: 'test',
+              address: 'test',
+              id: 'test'
+            },
+            account: 'account',
+            wasm: 'wasm'
+          }
+        })
+        .matches('deploy.pending')
+    ).toBeFalsy()
+  })
+
+  it('Should transition all the way to final', async () =>
+    new Promise((resolve) => {
+      const mockToggleMachine = stateMachine.withConfig({
+        services: {
+          deploy: () =>
+            Promise.resolve({
+              txID: 'txID',
+              entities: [],
+              badgeMetadata: [],
+              badgeName: 'badgename'
+            })
+        }
+      })
+
+      const fetchMachine = interpret(mockToggleMachine).onTransition(
+        (state) => {
+          if (state.matches('deploy.pending')) {
+            expect(state.matches('deploy.pending')).toBeTruthy()
+          }
+          if (state.matches('deploy.success')) {
+            expect(state.matches('deploy.success')).toBeTruthy()
+            resolve('done')
+          }
+        }
+      )
+      fetchMachine.start()
+      fetchMachine.send({
+        type: 'DEPLOY',
+        payload: {
+          badge: {
+            name: 'test',
+            address: 'test',
+            id: 'test'
+          },
+          account: 'account',
+          wasm: 'wasm',
+          abi: 'abi'
+        }
+      })
+    }))
+})


### PR DESCRIPTION
the reason for the problem is that the $state.context state is refreshed on every time a send command is executed. since we're passsing a new option array on state changes the component refreshes each time which causes the selector to unselect.

the solution i settled with is to extract the mapping of the options outside of the jsx rendering. this way it only happens once, namely, when the account is selected and nft resources have been fetched