### PR TITLE
"Deploy Package" fixes

### DIFF
--- a/src/components/_navbar-pages/deploy-package/DeployPackage.svelte
+++ b/src/components/_navbar-pages/deploy-package/DeployPackage.svelte
@@ -179,7 +179,7 @@
     </Box>
   </Box>
 
-  <Box hidden={!selectedAccount}>
+  <Box hidden={!$selectedAccount}>
     <Text>
       <Text
         on:click={() => {


### PR DESCRIPTION
- show "create badge" only if account selected
- display shortened account address only once