### PR TITLE
Use github sha and environment as tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,6 @@ jobs:
             type=semver,pattern={{version}}
 
       - name: Define network name
-        id: network
         run: |
           if [ "${{ github.event_name}}" = 'workflow_dispatch' ]; then
             echo "NETWORK_NAME="${{ github.event.inputs.ENVIRONMENT_NAME }}"" >> $GITHUB_ENV
@@ -116,7 +115,8 @@ jobs:
           elif [ "${{ github.ref }}" = "refs/heads/main" -a "${{ github.event_name }}" = 'push' ] || [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "NETWORK_NAME=${{ env.active_network }}" >> $GITHUB_ENV
           fi
-
+      - id: network
+        run: |
           echo "network-name=${{ env.NETWORK_NAME }}" >> $GITHUB_OUTPUT
       - id: tag-with-network
         run: |

--- a/.github/workflows/console-ci.yaml
+++ b/.github/workflows/console-ci.yaml
@@ -96,7 +96,6 @@ jobs:
             type=sha,event=branch
             type=semver,pattern={{version}}
       - name: Define network name
-        id: network
         run: |
           if [ "${{ github.event_name}}" = 'workflow_dispatch' ]; then
             echo "NETWORK_NAME="${{ github.event.inputs.ENVIRONMENT_NAME }}"" >> $GITHUB_ENV
@@ -105,7 +104,8 @@ jobs:
           elif [ "${{ github.ref }}" = "refs/heads/main" -a "${{ github.event_name }}" = 'push' ] || [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "NETWORK_NAME=${{ env.active_network }}" >> $GITHUB_ENV
           fi
-
+      - id: network
+        run: |
           echo "network-name=${{ env.NETWORK_NAME }}" >> $GITHUB_OUTPUT
       - id: tag-with-network
         run: |


### PR DESCRIPTION
Issue: The same tag was rebuilt when different environments were deployed using same commit.  This PR fixes this by adding network name as suffix to the tag.

Ex - https://github.com/radixdlt/dapps-monorepo/actions/runs/6411064437/job/17406066570#step:12:90
