### PR TITLE
ci: run snyk image scan in ci only on mainnet and stokenet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -317,7 +317,8 @@ jobs:
           secret_prefix: 'SNYK'
           secret_name: 'arn:aws:secretsmanager:eu-west-2:308190735829:secret:github-actions/common/snyk-credentials-rXRpuX'
           parse_json: true
-      - name: Snyk image scan
+      - if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.ENVIRONMENT_NAME == 'stokenet' || github.event.inputs.ENVIRONMENT_NAME == 'mainnet'))
+        name: Snyk image scan
         uses: snyk/actions/docker@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
         with:
           image: docker.io/radixdlt/dapps-dashboard:${{ needs.setup-tags.outputs.tag-with-network }}
@@ -370,7 +371,8 @@ jobs:
           secret_prefix: 'SNYK'
           secret_name: 'arn:aws:secretsmanager:eu-west-2:308190735829:secret:github-actions/common/snyk-credentials-rXRpuX'
           parse_json: true
-      - name: Snyk image scan
+      - if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.ENVIRONMENT_NAME == 'stokenet' || github.event.inputs.ENVIRONMENT_NAME == 'mainnet'))
+        name: Snyk image scan
         uses: snyk/actions/docker@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
         with:
           image: docker.io/radixdlt/dapps-dashboard-storybook:${{ needs.setup-tags.outputs.tag-with-network }}

--- a/.github/workflows/console-ci.yaml
+++ b/.github/workflows/console-ci.yaml
@@ -298,7 +298,8 @@ jobs:
           secret_prefix: 'SNYK'
           secret_name: 'arn:aws:secretsmanager:eu-west-2:308190735829:secret:github-actions/common/snyk-credentials-rXRpuX'
           parse_json: true
-      - name: Snyk image scan
+      - if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.ENVIRONMENT_NAME == 'stokenet' || github.event.inputs.ENVIRONMENT_NAME == 'mainnet'))
+        name: Snyk image scan
         uses: snyk/actions/docker@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
         with:
           image: docker.io/radixdlt/dapps-console:${{ needs.setup-tags.outputs.tag-with-network }}


### PR DESCRIPTION
Run snyk image scan in ci only on mainnet and stokenet. We have also active snyk image monitoring so the vulnerability will be reported in Snyk dashboard earlier.