### PR TITLE
ci: don't fail on snyk vulnerabilities which doesn't have fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -317,8 +317,7 @@ jobs:
           secret_prefix: 'SNYK'
           secret_name: 'arn:aws:secretsmanager:eu-west-2:308190735829:secret:github-actions/common/snyk-credentials-rXRpuX'
           parse_json: true
-      - if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.ENVIRONMENT_NAME == 'stokenet' || github.event.inputs.ENVIRONMENT_NAME == 'mainnet'))
-        name: Snyk image scan
+      - name: Snyk image scan
         uses: snyk/actions/docker@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
         with:
           image: docker.io/radixdlt/dapps-dashboard:${{ needs.setup-tags.outputs.tag-with-network }}
@@ -371,8 +370,7 @@ jobs:
           secret_prefix: 'SNYK'
           secret_name: 'arn:aws:secretsmanager:eu-west-2:308190735829:secret:github-actions/common/snyk-credentials-rXRpuX'
           parse_json: true
-      - if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.ENVIRONMENT_NAME == 'stokenet' || github.event.inputs.ENVIRONMENT_NAME == 'mainnet'))
-        name: Snyk image scan
+      - name: Snyk image scan
         uses: snyk/actions/docker@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
         with:
           image: docker.io/radixdlt/dapps-dashboard-storybook:${{ needs.setup-tags.outputs.tag-with-network }}

--- a/.github/workflows/console-ci.yaml
+++ b/.github/workflows/console-ci.yaml
@@ -298,8 +298,7 @@ jobs:
           secret_prefix: 'SNYK'
           secret_name: 'arn:aws:secretsmanager:eu-west-2:308190735829:secret:github-actions/common/snyk-credentials-rXRpuX'
           parse_json: true
-      - if: (github.event_name == 'workflow_dispatch' && (github.event.inputs.ENVIRONMENT_NAME == 'stokenet' || github.event.inputs.ENVIRONMENT_NAME == 'mainnet'))
-        name: Snyk image scan
+      - name: Snyk image scan
         uses: snyk/actions/docker@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
         with:
           image: docker.io/radixdlt/dapps-console:${{ needs.setup-tags.outputs.tag-with-network }}


### PR DESCRIPTION
Pass snyk image scan job if there is vulnerability found but there is no fixed version yet (this is how `--fail-on=all` works 🙃  )