### PR TITLE
fix: do not display pool units with amount '0' [PTD-1287]

### DIFF
--- a/apps/dashboard/src/lib/summary/summary.ts
+++ b/apps/dashboard/src/lib/summary/summary.ts
@@ -239,7 +239,13 @@ export const produceSummary = (
 
   const poolData = Promise.all([account, fungibleResources, ledgerState]).then(
     ([account, fungibles, { stateVersion }]) => {
-      const poolUnits = getPoolUnits(fungibles)
+      const filterOutZeroBalanceUnits = (units: PoolUnit[]): PoolUnit[] =>
+        units.filter(
+          (unit) =>
+            account.resources.fungible.find((f) => f.address === unit.address)
+              ?.value !== '0'
+        )
+      const poolUnits = filterOutZeroBalanceUnits(getPoolUnits(fungibles))
       return getPoolUnitData(stateVersion, account)(poolUnits)
     }
   )


### PR DESCRIPTION
original issue mentioned in the ticket was resolved by other changes related to how we calculate pool units redemption value