### PR TITLE
Reduce api calls on network staking

### DIFF
--- a/apps/dashboard/src/pages/navbar-pages/staking/Validators.svelte
+++ b/apps/dashboard/src/pages/navbar-pages/staking/Validators.svelte
@@ -42,9 +42,10 @@
   import type { ValidatorListItem } from '@api/utils/entities/component/validator'
   import AvailableToStake from './available-to-stake/AvailableToStake.svelte'
   import { track } from '../../../routes/+layout.svelte'
+  import type { ResultAsync } from 'neverthrow'
 
   export let validators: Promise<ValidatorListItem<true, true, true>[]>
-  export let totalXrdBalance: Promise<string>
+  export let totalXrdBalance: ResultAsync<string, { code: string }>
   export let filteredValidators:
     | ValidatorListItem<true, true, true>[]
     | undefined = undefined

--- a/apps/dashboard/src/pages/navbar-pages/staking/available-to-stake/AvailableToStake.svelte
+++ b/apps/dashboard/src/pages/navbar-pages/staking/available-to-stake/AvailableToStake.svelte
@@ -2,8 +2,9 @@
   import SkeletonLoader from '@components/_base/skeleton-loader/SkeletonLoader.svelte'
   import TokenIcon from '@components/_base/token-icon/TokenIcon.svelte'
   import { formatXRDValue } from '@utils'
+  import type { ResultAsync } from 'neverthrow'
 
-  export let xrdAvailableToStake: Promise<string>
+  export let xrdAvailableToStake: ResultAsync<string, { code: string }>
 </script>
 
 <div class="card available-to-stake">
@@ -11,9 +12,13 @@
   <div class="text">XRD available to be staked:</div>
   <div class="amount">
     {#await xrdAvailableToStake}
-      <SkeletonLoader />
+      <SkeletonLoader width={50} />
     {:then amount}
-      {formatXRDValue(amount)}
+      {#if amount.isOk()}
+        {formatXRDValue(amount.value)}
+      {:else}
+        <SkeletonLoader width={50} />
+      {/if}
     {/await}
   </div>
 </div>

--- a/packages/ui/src/api/_deprecated/utils/entities/resource.ts
+++ b/packages/ui/src/api/_deprecated/utils/entities/resource.ts
@@ -568,6 +568,18 @@ export const getAccountData = (
     )
   )()
 
+export const getAccountDataV2 = (
+  accounts: StateEntityDetailsVaultResponseItem[],
+  options?: StateEntityDetailsOptions,
+  ledgerState?: LedgerStateSelector,
+  getNonFungiblesForResources?: string[]
+) =>
+  transformResources(
+    options,
+    ledgerState,
+    getNonFungiblesForResources
+  )(accounts)
+
 export const getAccountFungibleTokens = (accounts: string) =>
   pipe(
     () => getSingleEntityDetails(accounts),


### PR DESCRIPTION
Previously we were getting XRD balance for each shared accounts separately and there was one API call on top of that to get staking state. This is all now aggregated into single API call