### PR TITLE
fix: skip auth token renew

### DIFF
--- a/apps/dashboard/src/routes/+layout.svelte
+++ b/apps/dashboard/src/routes/+layout.svelte
@@ -113,11 +113,6 @@
 
     rdt.walletApi.walletData$.subscribe(({ accounts }) => {
       updateAccounts(accounts)
-      if (accounts.length > 0) {
-        authApi.renewAuthToken().mapErr((err) => {
-          rdt.disconnect()
-        })
-      }
     })
 
     resolveRDT(rdt)


### PR DESCRIPTION
this doesn't work for initial login because `renew` is fired before `login` finishes