### PR TITLE
fix: default unit_redemption_value to `1`

### DIFF
--- a/packages/ui/src/api/utils/staking.ts
+++ b/packages/ui/src/api/utils/staking.ts
@@ -106,7 +106,7 @@ export const getStakedInfo =
           stakeUnitToken.address
         )!
         const multiplier =
-          stakeUnitNativeResourceDetails.unit_redemption_value[0].amount
+          stakeUnitNativeResourceDetails.unit_redemption_value[0].amount || '1'
 
         const xrdAmount = new BigNumber(stakeUnitToken.value)
           .multipliedBy(new BigNumber(multiplier!))


### PR DESCRIPTION
for one of the staking units gateway is not returning this value causing UI to display `NaN`